### PR TITLE
corridor flat oversample

### DIFF
--- a/Class_imbalances.ipynb
+++ b/Class_imbalances.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# corridorr flat is de enige die minder dan 200 count heeft terwijl de rest 500 heeft, dus deze oversampele\n",
+    "# zodat er geen class imbalance is :D \n",
+    "\n",
+    "import pandas as pd\n",
+    "from sklearn.utils import resample\n",
+    "\n",
+    "df = #dataset\n",
+    "\n",
+    "\n",
+    "klasse_col = 'woningtype'\n",
+    "\n",
+    "#Split de corridorflat weg van de rest\n",
+    "df_majority = df[df[klasse_col] != 'Corridorflat']  \n",
+    "df_minority = df[df[klasse_col] == 'Corridorflat'] \n",
+    "\n",
+    "# Oversample corriderflat door random te dupliceren\n",
+    "df_minority_oversampled = resample(\n",
+    "    df_minority,\n",
+    "    replace=True,                \n",
+    "    n_samples=500,               \n",
+    "    random_state=42            \n",
+    ")\n",
+    "\n",
+    "#voeg ze weer samen\n",
+    "df_balanced = pd.concat([df_majority, df_minority_oversampled])\n",
+    "\n",
+    "#shuffle de volgorde zodat het nog een beetje door elkaar zit\n",
+    "df_balanced = df_balanced.sample(frac=1, random_state=42).reset_index(drop=True)\n",
+    "\n",
+    "#print de klasses counts om te checken (Het werkte als het goed is toen ik het teste in datavisualisatie)\n",
+    "woningtype_counts = df_balanced['woningtype'].value_counts(dropna=False)\n",
+    "print(\"Woningtype Counts:\\n\", woningtype_counts)\n",
+    "\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Bij datavisualisatie was corridorflat de enige klassen die niet 500 samples had, dus heb deze ge-oversampled zodat er geen class imbalance  is :)